### PR TITLE
Add CRTP PWM module for direct motor control

### DIFF
--- a/src/modules/interface/crtp.h
+++ b/src/modules/interface/crtp.h
@@ -47,6 +47,7 @@ typedef enum {
   CRTP_PORT_LOCALIZATION     = 0x06,
   CRTP_PORT_SETPOINT_GENERIC = 0x07,
   CRTP_PORT_SETPOINT_HL      = 0x08,
+  CRTP_PORT_PWM              = 0x0A,
   CRTP_PORT_PLATFORM         = 0x0D,
   CRTP_PORT_LINK             = 0x0F,
 } CRTPPort;

--- a/src/modules/interface/crtp_pwm.h
+++ b/src/modules/interface/crtp_pwm.h
@@ -1,0 +1,30 @@
+/**
+ *    ||          ____  _ __
+ * +------+      / __ )(_) /_______________ _____  ___
+ * | 0xBC |     / __  / / __/ ___/ ___/ __ `/_  / / _ \
+ * +------+    / /_/ / / /_/ /__/ /  / /_/ / / /_/  __/
+ *  ||  ||    /_____/_/\__/\___/_/   \__,_/ /___/\___/
+ *
+ * Crazyflie Firmware
+ */
+
+#pragma once
+
+#include "autoconf.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#ifdef CONFIG_CRTP_PWM
+void crtpPwmInit(void);
+void crtpPwmStep(void);
+#else
+static inline void crtpPwmInit(void) {}
+static inline void crtpPwmStep(void) {}
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+

--- a/src/modules/src/Kbuild
+++ b/src/modules/src/Kbuild
@@ -13,6 +13,7 @@ obj-y += crtp_commander_rpyt.o
 obj-y += crtp_localization_service.o
 obj-y += crtp.o
 obj-y += crtpservice.o
+obj-$(CONFIG_CRTP_PWM) += crtp_pwm.o
 obj-y += esp_deck_flasher.o
 obj-y += eventtrigger.o
 obj-y += extrx.o

--- a/src/modules/src/Kconfig
+++ b/src/modules/src/Kconfig
@@ -1,3 +1,7 @@
+config CRTP_PWM
+    bool "Enable CRTP PWM control"
+    default y
+
 menu "Controllers and Estimators"
 
 choice

--- a/src/modules/src/crtp_pwm.c
+++ b/src/modules/src/crtp_pwm.c
@@ -1,0 +1,104 @@
+/**
+ *    ||          ____  _ __
+ * +------+      / __ )(_) /_______________ _____  ___
+ * | 0xBC |     / __  / / __/ ___/ ___/ __ `/_  / / _ \
+ * +------+    / /_/ / / /_/ /__/ /  / /_/ / / /_/  __/
+ *  ||  ||    /_____/_/\__/\___/_/   \__,_/ /___/\___/
+ *
+ * Crazyflie Firmware
+ */
+
+#define DEBUG_MODULE "CRTP_PWM"
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#include "FreeRTOS.h"
+#include "task.h"
+
+#include "crtp.h"
+#include "crtp_pwm.h"
+#include "motors.h"
+#include "param.h"
+#include "log.h"
+
+struct pwmPacket_s {
+  uint16_t m1;
+  uint16_t m2;
+  uint16_t m3;
+  uint16_t m4;
+} __attribute__((packed));
+
+static struct {
+  uint16_t m[4];
+  TickType_t tick;
+  uint16_t seq;
+} rx;
+
+static uint8_t enable = 0;
+static uint16_t timeoutMs = 50;
+static bool wasEnabled = false;
+
+static void crtpPwmCrtpCB(CRTPPacket* pk)
+{
+  if (pk->size < sizeof(struct pwmPacket_s)) {
+    return;
+  }
+  const struct pwmPacket_s* p = (const struct pwmPacket_s*)pk->data;
+  rx.m[0] = p->m1;
+  rx.m[1] = p->m2;
+  rx.m[2] = p->m3;
+  rx.m[3] = p->m4;
+  rx.tick = xTaskGetTickCountFromISR();
+  rx.seq++;
+}
+
+void crtpPwmInit(void)
+{
+  crtpInit();
+  crtpRegisterPortCB(CRTP_PORT_PWM, crtpPwmCrtpCB);
+}
+
+void crtpPwmStep(void)
+{
+  TickType_t now = xTaskGetTickCount();
+
+  if (!enable) {
+    if (wasEnabled) {
+      motorsSetRatio(MOTOR_M1, 0);
+      motorsSetRatio(MOTOR_M2, 0);
+      motorsSetRatio(MOTOR_M3, 0);
+      motorsSetRatio(MOTOR_M4, 0);
+      wasEnabled = false;
+    }
+    return;
+  }
+
+  wasEnabled = true;
+
+  if (T2M(now - rx.tick) <= timeoutMs) {
+    motorsSetRatio(MOTOR_M1, rx.m[0]);
+    motorsSetRatio(MOTOR_M2, rx.m[1]);
+    motorsSetRatio(MOTOR_M3, rx.m[2]);
+    motorsSetRatio(MOTOR_M4, rx.m[3]);
+  } else {
+    motorsSetRatio(MOTOR_M1, 0);
+    motorsSetRatio(MOTOR_M2, 0);
+    motorsSetRatio(MOTOR_M3, 0);
+    motorsSetRatio(MOTOR_M4, 0);
+  }
+}
+
+PARAM_GROUP_START(crtp_pwm)
+PARAM_ADD(PARAM_UINT8, enable, &enable)
+PARAM_ADD(PARAM_UINT16, timeoutMs, &timeoutMs)
+PARAM_GROUP_STOP(crtp_pwm)
+
+LOG_GROUP_START(crtp_pwm)
+LOG_ADD(LOG_UINT16, m1, &rx.m[0])
+LOG_ADD(LOG_UINT16, m2, &rx.m[1])
+LOG_ADD(LOG_UINT16, m3, &rx.m[2])
+LOG_ADD(LOG_UINT16, m4, &rx.m[3])
+LOG_ADD(LOG_UINT16, seq, &rx.seq)
+LOG_GROUP_STOP(crtp_pwm)
+

--- a/src/modules/src/stabilizer.c
+++ b/src/modules/src/stabilizer.c
@@ -44,6 +44,7 @@
 #include "commander.h"
 #include "crtp_commander_high_level.h"
 #include "crtp_localization_service.h"
+#include "crtp_pwm.h"
 #include "controller.h"
 #include "power_distribution.h"
 #include "collision_avoidance.h"
@@ -373,6 +374,7 @@ static void stabilizerTask(void* param)
       STATS_CNT_RATE_EVENT(&stabilizerRate);
     }
 
+    crtpPwmStep();
     xSemaphoreGive(xRateSupervisorSemaphore);
 
 #ifdef CONFIG_MOTORS_ESC_PROTOCOL_DSHOT

--- a/src/modules/src/system.c
+++ b/src/modules/src/system.c
@@ -56,6 +56,7 @@
 #include "usblink.h"
 #include "mem.h"
 #include "crtp_mem.h"
+#include "crtp_pwm.h"
 #include "proximity.h"
 #include "watchdog.h"
 #include "queuemonitor.h"
@@ -187,6 +188,7 @@ void systemTask(void *arg)
   systemInit();
   commInit();
   commanderInit();
+  crtpPwmInit();
 
   StateEstimatorType estimator = StateEstimatorTypeAutoSelect;
 


### PR DESCRIPTION
## Summary
- add CRTP_PORT_PWM and a CRTP PWM module to drive motors directly
- expose crtp_pwm.enable and timeout parameters and log m1..m4 and seq
- integrate module into system init and stabilizer loop

## Testing
- `make bolt_defconfig`
- `make -j` *(fails: arm-none-eabi-gcc: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a20ce770fc83308f58c9e2ad37732f