### PR TITLE
chore: add lint job to cf-bolt CI

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,2 +1,3 @@
 [flake8]
-max-line-length:120
+max-line-length = 120
+extend-ignore = E203,W503

--- a/.github/workflows/cf-bolt-ci.yml
+++ b/.github/workflows/cf-bolt-ci.yml
@@ -1,0 +1,53 @@
+name: cf-bolt CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - run: python -m pip install --upgrade pip
+      - run: pip install yamllint flake8
+      - run: yamllint .github/workflows/
+      - run: |
+          if [ -f test_python/test_4pwm.py ]; then
+            flake8 test_python/test_4pwm.py
+          else
+            echo "test_python/test_4pwm.py not found, skipping flake8"
+          fi
+
+  build-bolt:
+    runs-on: ubuntu-latest
+    needs: lint
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: true
+      - name: Install ARM toolchain
+        run: sudo apt-get update && sudo apt-get install -y gcc-arm-none-eabi
+      - name: Build
+        run: |
+          make bolt_defconfig
+          make -j
+      - name: Upload build artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: cf2-bolt
+          path: build/bolt/cf2.bin
+
+  dryrun-python:
+    runs-on: ubuntu-latest
+    needs: lint
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Dry run
+        run: python test_python/test_4pwm.py --dry-run

--- a/.yamllint.yml
+++ b/.yamllint.yml
@@ -1,0 +1,5 @@
+extends: default
+rules:
+  line-length:
+    max: 140
+    level: warning


### PR DESCRIPTION
## Summary
- run yamllint and flake8 in new lint job
- gate build and dryrun on lint
- configure flake8 and yamllint defaults

## Testing
- `flake8 test_python/test_4pwm.py` *(fails: command not found)*
- `yamllint .github/workflows` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a2202dca388330960ca9606b315292