### PR TITLE
Add CRTP PWM motor injection support

### DIFF
--- a/src/modules/interface/crtp_pwm.h
+++ b/src/modules/interface/crtp_pwm.h
@@ -12,6 +12,13 @@
 
 #include "autoconf.h"
 
+#include <stdbool.h>
+
+#include "FreeRTOS.h"
+#include "stabilizer_types.h"
+
+#define CRTP_PWM_FAILSAFE_TIMEOUT_MS 200
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -19,9 +26,24 @@ extern "C" {
 #ifdef CONFIG_CRTP_PWM
 void crtpPwmInit(void);
 void crtpPwmStep(void);
+bool crtpPwmInjectionIsEnabled(void);
+bool crtpPwmGetMotorThrust(motors_thrust_uncapped_t* motorThrust, TickType_t* lastPacketTick);
 #else
 static inline void crtpPwmInit(void) {}
 static inline void crtpPwmStep(void) {}
+static inline bool crtpPwmInjectionIsEnabled(void) { return false; }
+static inline bool crtpPwmGetMotorThrust(motors_thrust_uncapped_t* motorThrust, TickType_t* lastPacketTick)
+{
+  if (motorThrust) {
+    for (int motor = 0; motor < STABILIZER_NR_OF_MOTORS; motor++) {
+      motorThrust->list[motor] = 0;
+    }
+  }
+  if (lastPacketTick) {
+    *lastPacketTick = 0;
+  }
+  return false;
+}
 #endif
 
 #ifdef __cplusplus

--- a/src/modules/src/crtp_pwm.c
+++ b/src/modules/src/crtp_pwm.c
@@ -12,13 +12,13 @@
 
 #include <stdbool.h>
 #include <stdint.h>
+#include <limits.h>
 
 #include "FreeRTOS.h"
 #include "task.h"
 
 #include "crtp.h"
 #include "crtp_pwm.h"
-#include "motors.h"
 #include "param.h"
 #include "log.h"
 
@@ -30,26 +30,43 @@ struct pwmPacket_s {
 } __attribute__((packed));
 
 static struct {
-  uint16_t m[4];
+  uint16_t m[STABILIZER_NR_OF_MOTORS];
   TickType_t tick;
-  uint16_t seq;
+  volatile uint16_t seq;
+  volatile bool hasPacket;
 } rx;
 
-static uint8_t enable = 0;
-static uint16_t timeoutMs = 50;
-static bool wasEnabled = false;
+static uint32_t sinceLastRxMs = UINT32_MAX;
+
+static uint8_t crtpPwmEnable = 0;
+static uint8_t pwmEnable = 0;
+static paramVarId_t motorPowerSetEnableParam;
+
+static bool isMotorPowerSetInjectionEnabled(void)
+{
+  if (!PARAM_VARID_IS_VALID(motorPowerSetEnableParam)) {
+    return false;
+  }
+
+  return paramGetInt(motorPowerSetEnableParam) == 1;
+}
 
 static void crtpPwmCrtpCB(CRTPPacket* pk)
 {
-  if (pk->size < sizeof(struct pwmPacket_s)) {
+  if (pk->channel != 0) {
     return;
   }
+  if (pk->size != sizeof(struct pwmPacket_s)) {
+    return;
+  }
+
   const struct pwmPacket_s* p = (const struct pwmPacket_s*)pk->data;
   rx.m[0] = p->m1;
   rx.m[1] = p->m2;
   rx.m[2] = p->m3;
   rx.m[3] = p->m4;
   rx.tick = xTaskGetTickCountFromISR();
+  rx.hasPacket = true;
   rx.seq++;
 }
 
@@ -57,42 +74,70 @@ void crtpPwmInit(void)
 {
   crtpInit();
   crtpRegisterPortCB(CRTP_PORT_PWM, crtpPwmCrtpCB);
+
+  rx.tick = 0;
+  rx.seq = 0;
+  rx.hasPacket = false;
+  sinceLastRxMs = UINT32_MAX;
+
+  motorPowerSetEnableParam = paramGetVarId("motorPowerSet", "enable");
 }
 
 void crtpPwmStep(void)
 {
-  TickType_t now = xTaskGetTickCount();
+  TickType_t lastTick = 0;
+  const bool hasPacket = crtpPwmGetMotorThrust(NULL, &lastTick);
+  const TickType_t now = xTaskGetTickCount();
 
-  if (!enable) {
-    if (wasEnabled) {
-      motorsSetRatio(MOTOR_M1, 0);
-      motorsSetRatio(MOTOR_M2, 0);
-      motorsSetRatio(MOTOR_M3, 0);
-      motorsSetRatio(MOTOR_M4, 0);
-      wasEnabled = false;
-    }
+  if (!hasPacket && lastTick == 0) {
+    sinceLastRxMs = T2M(now);
     return;
   }
 
-  wasEnabled = true;
+  sinceLastRxMs = T2M(now - lastTick);
+}
 
-  if (T2M(now - rx.tick) <= timeoutMs) {
-    motorsSetRatio(MOTOR_M1, rx.m[0]);
-    motorsSetRatio(MOTOR_M2, rx.m[1]);
-    motorsSetRatio(MOTOR_M3, rx.m[2]);
-    motorsSetRatio(MOTOR_M4, rx.m[3]);
-  } else {
-    motorsSetRatio(MOTOR_M1, 0);
-    motorsSetRatio(MOTOR_M2, 0);
-    motorsSetRatio(MOTOR_M3, 0);
-    motorsSetRatio(MOTOR_M4, 0);
+bool crtpPwmInjectionIsEnabled(void)
+{
+  return (crtpPwmEnable != 0) || (pwmEnable != 0) || isMotorPowerSetInjectionEnabled();
+}
+
+bool crtpPwmGetMotorThrust(motors_thrust_uncapped_t* motorThrust, TickType_t* lastPacketTick)
+{
+  uint16_t localValues[STABILIZER_NR_OF_MOTORS];
+  TickType_t tickSnapshot;
+  uint16_t seqSnapshot;
+  bool hasPacket;
+
+  do {
+    seqSnapshot = rx.seq;
+    hasPacket = rx.hasPacket;
+    for (int motor = 0; motor < STABILIZER_NR_OF_MOTORS; motor++) {
+      localValues[motor] = rx.m[motor];
+    }
+    tickSnapshot = rx.tick;
+  } while (seqSnapshot != rx.seq);
+
+  if (motorThrust) {
+    for (int motor = 0; motor < STABILIZER_NR_OF_MOTORS; motor++) {
+      motorThrust->list[motor] = localValues[motor];
+    }
   }
+
+  if (lastPacketTick) {
+    *lastPacketTick = tickSnapshot;
+  }
+
+  return hasPacket;
 }
 
 PARAM_GROUP_START(crtp_pwm)
-PARAM_ADD(PARAM_UINT8, enable, &enable)
-PARAM_ADD(PARAM_UINT16, timeoutMs, &timeoutMs)
+PARAM_ADD(PARAM_UINT8, enable, &crtpPwmEnable)
 PARAM_GROUP_STOP(crtp_pwm)
+
+PARAM_GROUP_START(pwm)
+PARAM_ADD(PARAM_UINT8, enable, &pwmEnable)
+PARAM_GROUP_STOP(pwm)
 
 LOG_GROUP_START(crtp_pwm)
 LOG_ADD(LOG_UINT16, m1, &rx.m[0])
@@ -101,4 +146,12 @@ LOG_ADD(LOG_UINT16, m3, &rx.m[2])
 LOG_ADD(LOG_UINT16, m4, &rx.m[3])
 LOG_ADD(LOG_UINT16, seq, &rx.seq)
 LOG_GROUP_STOP(crtp_pwm)
+
+LOG_GROUP_START(pwminject)
+LOG_ADD(LOG_UINT16, rx_m1, &rx.m[0])
+LOG_ADD(LOG_UINT16, rx_m2, &rx.m[1])
+LOG_ADD(LOG_UINT16, rx_m3, &rx.m[2])
+LOG_ADD(LOG_UINT16, rx_m4, &rx.m[3])
+LOG_ADD(LOG_UINT32, since_last_rx, &sinceLastRxMs)
+LOG_GROUP_STOP(pwminject)
 

--- a/src/modules/src/stabilizer.c
+++ b/src/modules/src/stabilizer.c
@@ -254,7 +254,29 @@ static void logCapWarning(const bool isCapped) {
 }
 
 static void controlMotors(const control_t* control) {
-  powerDistribution(control, &motorThrustUncapped);
+  if (!crtpPwmInjectionIsEnabled()) {
+    powerDistribution(control, &motorThrustUncapped);
+  } else {
+    motors_thrust_uncapped_t injectedThrust;
+    TickType_t lastPacketTick = 0;
+    const bool hasPacket = crtpPwmGetMotorThrust(&injectedThrust, &lastPacketTick);
+    const TickType_t now = xTaskGetTickCount();
+    const TickType_t timeoutTicks = M2T(CRTP_PWM_FAILSAFE_TIMEOUT_MS);
+    bool streamFresh = false;
+
+    if (hasPacket) {
+      streamFresh = (now - lastPacketTick) <= timeoutTicks;
+    }
+
+    if (streamFresh) {
+      motorThrustUncapped = injectedThrust;
+    } else {
+      for (int motor = 0; motor < STABILIZER_NR_OF_MOTORS; motor++) {
+        motorThrustUncapped.list[motor] = 0;
+      }
+    }
+  }
+
   batteryCompensation(&motorThrustUncapped, &motorThrustBatCompUncapped);
   const bool isCapped = powerDistributionCap(&motorThrustBatCompUncapped, &motorPwm);
   logCapWarning(isCapped);


### PR DESCRIPTION
## Summary
- add a CRTP port 0x0A handler that caches 4-PWM packets, exposes enable params (`crtp_pwm.enable`, `pwm.enable`, `motorPowerSet.enable`) and logs the most recent values
- update the stabilizer motor pipeline to inject cached PWM commands ahead of battery compensation with a ~200 ms watchdog fallback to zero

## Testing
- `make cf2_defconfig`
- `make -j4` *(fails: arm-none-eabi-gcc not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cd9fb72c888330bae19b5eb50b6550